### PR TITLE
file: remove dep on vcredist

### DIFF
--- a/file/file.nuspec
+++ b/file/file.nuspec
@@ -98,9 +98,6 @@ Report bugs to https://bugs.astron.com/
 * PR/259: aleksandr.v.novichkov: mime printing through indirect magic
 * count the total bytes found not the total byte positions
     </releaseNotes>
-    <dependencies>
-      <dependency id="vcredist140" version="14.16.27024.1" />
-    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
As of 5.42 it is now a fully static binary with the MSVC runtime
statically linked as well.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>